### PR TITLE
Add fix for CVE-2022-41940

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -433,6 +433,9 @@ class Server extends EventEmitter {
           // then the socket needs to die!
           setTimeout(function() {
             if (socket.writable && socket.bytesWritten <= 0) {
+              socket.on("error", e => {
+                debug("error while destroying upgrade: %s", e.message);
+              });
               return socket.end();
             }
           }, destroyUpgradeTimeout);


### PR DESCRIPTION
This PR fixes a high vulnerability (CVE-2022-41940) by handling exception for error due to an invalid HTTP2 upgrade

### Details

| **Field**              | **Description**                                                                                                                                          |
|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| **CVE ID**             | CVE-2022-41940                                                                                       |
| **Severity**           | High                                                                                                                                                     |
| **Summary**            | Engine.IO is the implementation of transport-based cross-browser/cross-device </br>bi-directional communication layer for Socket.IO. A specially crafted HTTP request can </br>trigger an uncaught exception on the Engine.IO server, thus killing the Node.js process. </br>This impacts all the users of the engine.io package, including those who uses depending </br>packages like socket.io. There is no known workaround except upgrading to a safe version. </br>There are patches for this issue released in versions 3.6.1 and 6.2.1. |
